### PR TITLE
chore: fix lint errors for local builds

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,8 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+// Use a type alias instead of an empty interface to satisfy lint rules
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+// Use a type alias instead of an empty interface to satisfy ESLint rules
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -115,5 +116,6 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  // Use ESM imports for Tailwind plugins to comply with eslint rules
+  plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- fix lint warnings due to empty interfaces in command and textarea components
- switch tailwindcss-animate to ESM import

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c00b411d908329b4e2051c8e60ee2c